### PR TITLE
Update to support MuPDF 1.19.x (latest version)

### DIFF
--- a/src/PDFLoader.cpp
+++ b/src/PDFLoader.cpp
@@ -7,12 +7,12 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>
  */
@@ -21,45 +21,45 @@
 #include "BaseTranslator.h"
 
 struct istream_filter {
-    BPositionIO *stream;
-    unsigned char buf[4096];
+	BPositionIO *stream;
+	unsigned char buf[4096];
 };
 
 static int next_istream(fz_context *ctx, fz_stream *stm, size_t max)
 {
-    istream_filter *state = (istream_filter *)stm->state;
-    int cbRead = sizeof(state->buf);        
-    
-    state->stream->Seek(stm->pos, SEEK_SET);
-    cbRead = state->stream->Read(state->buf, sizeof(state->buf));
-    
-    stm->rp = state->buf;
-    stm->wp = stm->rp + cbRead;
-    stm->pos += cbRead;
+	istream_filter *state = (istream_filter *)stm->state;
+	int cbRead = sizeof(state->buf);
 
-    return cbRead > 0 ? *stm->rp++ : EOF;
+	state->stream->Seek(stm->pos, SEEK_SET);
+	cbRead = state->stream->Read(state->buf, sizeof(state->buf));
+
+	stm->rp = state->buf;
+	stm->wp = stm->rp + cbRead;
+	stm->pos += cbRead;
+
+	return cbRead > 0 ? *stm->rp++ : EOF;
 }
 
 static void seek_istream(fz_context *ctx, fz_stream *stm, int64_t offset, int whence)
 {
-    istream_filter *state = (istream_filter *)stm->state;
-    state->stream->Seek(offset, whence);
-  	  	
-    stm->pos = state->stream->Position();
-    stm->rp = stm->wp = state->buf;
+	istream_filter *state = (istream_filter *)stm->state;
+	state->stream->Seek(offset, whence);
+
+	stm->pos = state->stream->Position();
+	stm->rp = stm->wp = state->buf;
 }
 
 static void close_istream(fz_context *ctx, void *state_)
 {
-    istream_filter *state = (istream_filter *)state_;
-    state->stream->Seek(0, SEEK_END);
-    fz_free(ctx, state);
+	istream_filter *state = (istream_filter *)state_;
+	state->stream->Seek(0, SEEK_END);
+	fz_free(ctx, state);
 }
 
 PDFLoader::PDFLoader(BPositionIO *source)
 {
 	fLoaded = false;
-	fDocumentType = 0;	
+	fDocumentType = 0;
 	fPageCount = 0;
 	fDPI = 72;
 	fAntialiasingBits = 8;
@@ -69,37 +69,37 @@ PDFLoader::PDFLoader(BPositionIO *source)
 	stream = NULL;
 
 	source->Seek(0, SEEK_SET);
-	
+
 	uint32 signatureData;
 	ssize_t signatureSize = 4;
 	if (source->Read(&signatureData, signatureSize) != signatureSize)
 		return;
-			
+
 	source->Seek(0, SEEK_SET);
-	
+
 	const uint32 kPDFMagic = B_HOST_TO_BENDIAN_INT32('%PDF');
-	
+
 	ctx = fz_new_context(NULL, NULL, FZ_STORE_UNLIMITED);
-	
+
 	istream_filter *state = fz_malloc_struct(ctx, istream_filter);
-    state->stream = source;
-        
-    stream = fz_new_stream(ctx, state, next_istream, close_istream);
-    
-    fz_register_document_handlers(ctx);
-    
-    stream->seek = seek_istream;
-        
+	state->stream = source;
+
+	stream = fz_new_stream(ctx, state, next_istream, close_istream);
+
+	fz_register_document_handlers(ctx);
+
+	stream->seek = seek_istream;
+
 	if (signatureData == kPDFMagic) {
 		fDocumentType = PDF_IMAGE_FORMAT;
-    	doc = fz_open_document_with_stream(ctx, "mupdf.pdf", stream);
+		doc = fz_open_document_with_stream(ctx, "mupdf.pdf", stream);
 	} else {
-    	return;    
+		return;
 	}
 
 	fPageCount = fz_count_pages(ctx, doc);
-	
-	fLoaded = true;	
+
+	fLoaded = true;
 }
 
 
@@ -125,8 +125,8 @@ uint32
 PDFLoader::DocumentType(void)
 {
 	return fDocumentType;
-}	
-	
+}
+
 
 int
 PDFLoader::PageCount(void)
@@ -158,21 +158,21 @@ PDFLoader::GetImage(BPositionIO *target, int index)
 	int rotation = 0;
 
 	fz_page *page = fz_load_page(ctx, doc, index - 1);
-	
+
 	fz_matrix transform = fz_rotate(rotation);
 	fz_pre_scale(transform, fDPI / 72.0f, fDPI / 72.0f);
-	
+
 	fz_set_aa_level(ctx, fAntialiasingBits);
 
 	fz_rect bounds = fz_bound_page(ctx, page);
 	fz_transform_rect(bounds, transform);
 
-	fz_irect bbox =	fz_round_rect(bounds);
-    fz_separations *seps = fz_page_separations(ctx, page);
+	fz_irect bbox = fz_round_rect(bounds);
+	fz_separations *seps = fz_page_separations(ctx, page);
 	fz_pixmap *pix = fz_new_pixmap_with_bbox(ctx, fz_device_rgb(ctx), bbox, seps, 1);
 	fz_clear_pixmap_with_value(ctx, pix, 0xff);
 
-    fz_matrix mat = fz_scale(1, 1);
+	fz_matrix mat = fz_scale(1, 1);
 	fz_device *dev = fz_new_draw_device(ctx, mat, pix);
 	if (fAntialiasingBits == 0)
 		fz_enable_device_hints(ctx, dev, FZ_DONT_INTERPOLATE_IMAGES);
@@ -189,7 +189,7 @@ PDFLoader::GetImage(BPositionIO *target, int index)
 	bitsHeader.colors = B_RGB32;
 	bitsHeader.dataSize = bitsHeader.rowBytes * pix->h;
 	if (swap_data(B_UINT32_TYPE, &bitsHeader,
-		sizeof(TranslatorBitmap), B_SWAP_HOST_TO_BENDIAN) != B_OK) {		
+		sizeof(TranslatorBitmap), B_SWAP_HOST_TO_BENDIAN) != B_OK) {
 		return B_NO_TRANSLATOR;
 	}
 	target->Write(&bitsHeader, sizeof(TranslatorBitmap));

--- a/src/PDFLoader.cpp
+++ b/src/PDFLoader.cpp
@@ -172,8 +172,7 @@ PDFLoader::GetImage(BPositionIO *target, int index)
 	fz_pixmap *pix = fz_new_pixmap_with_bbox(ctx, fz_device_rgb(ctx), bbox, seps, 1);
 	fz_clear_pixmap_with_value(ctx, pix, 0xff);
 
-	fz_matrix mat = fz_scale(1, 1);
-	fz_device *dev = fz_new_draw_device(ctx, mat, pix);
+	fz_device *dev = fz_new_draw_device(ctx, fz_identity, pix);
 	if (fAntialiasingBits == 0)
 		fz_enable_device_hints(ctx, dev, FZ_DONT_INTERPOLATE_IMAGES);
 	fz_run_page(ctx, page, dev, transform, NULL);


### PR DESCRIPTION
I've recently opened a pull request to update the version of MuPDF in HaikuPorts to 1.19.
https://github.com/haikuports/haikuports/pull/6823
To support this work, applications in the repo that depend on MuPDF will have to be updated as there have been several API changes.